### PR TITLE
feature(): fix/make the addon runnable in blender4.0.2

### DIFF
--- a/camera-set/Panel.py
+++ b/camera-set/Panel.py
@@ -77,11 +77,16 @@ class SCENE_PT_cameraset(Panel, CameraSetPanel):
 		                    camera_sett, "affected_settings_idx", rows=3)
 		col = row.column()
 		sub = col.column(align=True)
-		sub.operator("scene.render_camera_set_add", icon='ZOOMIN', text="")
-		sub.operator("scene.render_camera_set_remove", icon='ZOOMOUT', text="")
-		#col.prop(camera_sett, "use_single_layer", icon_only=True)
+
+		if bpy.app.version >= (4, 0, 2):
+			sub.operator("scene.render_camera_set_add", icon='ADD', text="")
+			sub.operator("scene.render_camera_set_remove", icon='TRASH', text="")
+			col = layout.split(factor=0.5)
+		else :
+			sub.operator("scene.render_camera_set_add", icon='ZOOMIN', text="")
+			sub.operator("scene.render_camera_set_remove", icon='ZOOMOUT', text="")
 		
-		col = layout.split(percentage=0.5)
+			col = layout.split(percentage=0.5)
 		col.operator("scene.render_camera_set_select", text="Add Selected Camera")
 		col.operator("scene.render_camera_set_deselect", text="Remove Selected Camera")
 

--- a/camera-set/__init__.py
+++ b/camera-set/__init__.py
@@ -1,14 +1,17 @@
 bl_info = {
 	"name": "Camera Render Set",
-	"author": "Valdemar Lindberg",
-	"version": (0, 1, 0),
-	"blender": (2, 79, 0),
+	"author": "Valdemar Lindberg, Co-Authored by Maurice Fernitz (Upgrade to blender 4.0)",
+	"version": (0, 2, 0),
+	"blender": (4, 0, 2),
 	"location": "Properties > Render",
 	"description": "A tool for creating a set of cameras that can be rendered in a single render command",
+	"support": "COMMUNITY",
+	"doc_url": "https://github.com/SevenOperation/Camera-Set-Addon",
 	"warning": "",
 	"wiki_url": "",
 	"category": "Render",
 }
+
 import bpy
 
 if "bpy" in locals():
@@ -45,15 +48,15 @@ class RenderCameraData(bpy.types.PropertyGroup):
 	def IsCameraObject(self, obj):
 		return obj.type == 'CAMERA'
 
-	name = StringProperty(name="name", default="", description="Name of the camera target.")
-	camera = PointerProperty(name="camera", type=bpy.types.Object,
+	name: StringProperty(name="name", default="", description="Name of the camera target.")
+	camera: PointerProperty(name="camera", type=bpy.types.Object,
 	                         description="Camera target object.", poll=IsCameraObject)  # ,
-	filepath = StringProperty(
+	filepath: StringProperty(
 		name="filepath", default='', subtype='FILE_PATH',
 		description="Relative filepath from the global output directory.")
 
-	enabled = BoolProperty(name="enabled", default=True, description="Target enabled for as a render target.")
-	affected_settings_idx = IntProperty()
+	enabled: BoolProperty(name="enabled", default=True, description="Target enabled for as a render target.")
+	affected_settings_idx: IntProperty()
 
 
 ## Future possible features ##
@@ -68,16 +71,15 @@ class RenderCameraData(bpy.types.PropertyGroup):
 
 class RenderCameraSetSceneSettings(bpy.types.PropertyGroup):
 	#
-	cameras = CollectionProperty(
-		type=RenderCameraData, name="cameras", description="")
-	affected_settings_idx = IntProperty()
-	output_directory = StringProperty(
+	cameras: CollectionProperty(type=RenderCameraData, name="cameras", description="")
+	affected_settings_idx: IntProperty()
+	output_directory: StringProperty(
 		name="Output Directory", description="", default="", subtype='DIR_PATH')
-	use_default_output_directory = BoolProperty(name="Use Default Output"
+	use_default_output_directory: BoolProperty(name="Use Default Output"
 	                                                 "Default Output",
 	                                            description="Use the directory specified in the Render section.",
 	                                            default=True)
-	enabled = BoolProperty(name="Enabled", description="", default=False)
+	enabled: BoolProperty(name="Enabled", description="", default=False)
 
 
 ## Future possible features ##
@@ -104,7 +106,10 @@ def register():
 	bpy.types.Scene.render_camera_set_settings = PointerProperty(type=RenderCameraSetSceneSettings)
 
 	# Create menus.
-	if bpy.app.version >= (2, 80, 0):
+	if bpy.app.version >= (4, 0, 0):
+		bpy.types.RENDER_PT_context.append(menu_func_render)
+		bpy.types.TOPBAR_MT_render.append(menu_func_render)
+	elif bpy.app.version >= (2, 80, 0):
 		bpy.types.RENDER_PT_render.append(menu_func_render)
 		bpy.types.TOPBAR_MT_render.append(menu_func_render)
 	else:
@@ -141,7 +146,10 @@ def unregister():
 	addon_keymaps.clear()
 
 	# Remove layouts.
-	if bpy.app.version >= (2, 80, 0):
+	if bpy.app.version >= (4, 0, 0):
+		bpy.types.RENDER_PT_context.remove(menu_func_render)
+		bpy.types.TOPBAR_MT_render.remove(menu_func_render)
+	elif bpy.app.version >= (2, 80, 0):
 		bpy.types.RENDER_PT_render.remove(menu_func_render)
 		bpy.types.TOPBAR_MT_render.remove(menu_func_render)
 	else:

--- a/camera-set/operator.py
+++ b/camera-set/operator.py
@@ -16,7 +16,6 @@ if "bpy" in locals():
 
 from bpy.types import RenderSettings, ImageFormatSettings
 from bpy.app.handlers import persistent
-from threading import Thread
 
 class RenderCameraBase:
 	bl_option = {'REGISTER', 'UNDO'}
@@ -202,13 +201,7 @@ class RenderCameraSet(Operator):
 	def execute(self, context):
 		wm = bpy.context.window_manager
 		self.timer = wm.event_timer_add(0.5, window=context.window)
-		wm.modal_handler_add(self)
 
-		self.thread = Thread(target=self._run, args=(context,))
-		self.thread.start()
-		return {'RUNNING_MODAL'}
-
-	def _run(self, context):
 		wm = bpy.context.window_manager
 		window = bpy.context.window_manager.windows[0]
 
@@ -293,35 +286,8 @@ class RenderCameraSet(Operator):
 				total_time = time.time() - time_start
 				self.report({'INFO'}, str.format("Total time: {} seconds", str(total_time)))
 
-				#
-				bpy.ops.render.view_show('INVOKE_DEFAULT')
-
-	def modal(self, context, event):
-		wm = context.window_manager
-		# Stop the thread when ESCAPE is pressed.
-		if event.type == 'ESC':
-			self.cancel(context)
-			return {'CANCEL'}
-#			self.state = ParallelRenderState.CANCELLING
-#			self._report_progress()
-
-		if event.type == 'TIMER':
-			still_running = self.thread.is_alive()
-			#with self.summary_mutex:
-			#	percent = 4
-
-			if still_running:
-				wm.progress_update(10)
-				#self._report_progress()
-				return {'PASS_THROUGH'}
-
-			self.thread.join()
-			wm.event_timer_remove(self.timer)
-			wm.progress_end()
-			bpy.ops.render.view_show('INVOKE_DEFAULT')
-			return {'FINISHED'}
-		return {'PASS_THROUGH'}
-
+				bpy.ops.render.view_show('INVOKE_DEFAULT')		
+				return {'RUNNING_MODAL'}
 
 	def invoke(self, context, event):
 		wm = context.window_manager


### PR DESCRIPTION
Removes threading since it always threw Access Violation Exceptions when trying to set the camera in the scene.
Use icons that exist in blender 4.0.2
Correct syntax for Propertys in Blender (filepath: StringProperty() instead of filepath= StringProperty() as an example) 
Correct type naming for UI in blender 4.0.2
